### PR TITLE
Fix Mixin Java version

### DIFF
--- a/fabric/1.21.3/files/resources/rename.mixins.json
+++ b/fabric/1.21.3/files/resources/rename.mixins.json
@@ -1,7 +1,7 @@
 {
 	"required": true,
 	"package": "%mkmod:package%.mixin",
-	"compatibilityLevel": "JAVA_21",
+	"compatibilityLevel": "JAVA_%mkmod:javaVersion%",
 	"mixins": [
 		"ExampleMixin"
 	],


### PR DESCRIPTION
fixes `compatibilityLevel` in `rename.mixins.json` (fabric template) by setting it to `%mkmod:javaVersion%` from `21`